### PR TITLE
adding gitignore to repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Gemfile.lock
+


### PR DESCRIPTION
I noticed after running `bundle install` that `Gemfile.lock` is listed as an untracked file. I'm assuming it's not already in the repository because we don't want it there.
