### PR TITLE
update .travis.yml to point to gini/puppet-archive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - 1.9.2
   - 1.9.3
 before_script:
-  - 'git clone git://github.com/smarchive/puppet-archive.git spec/fixtures/modules/archive'
+  - 'git clone git://github.com/gini/puppet-archive.git spec/fixtures/modules/archive'
 env:
   - PUPPET_VERSION=2.6.2
   - PUPPET_VERSION=2.6.18


### PR DESCRIPTION
I was looking at the `.travis.yml` to figure out how to build the project locally when I noticed it's cloning [smarchive/puppet-archive](https://github.com/smarchive/puppet-archive). The only file in that repository currently is a README that says the project has moved to [gini/puppet-archive](https://github.com/gini/puppet-archive).

This update reflects the change in that README.
