### PR TITLE
bump defaults to gradle 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Usage
 Example:
 
     class { 'gradle':
-      version => '1.6',
+      version => '1.8',
     }
 
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,7 +33,7 @@
 # === Examples
 #
 #  class { 'gradle':
-#    version => '1.6'
+#    version => '1.8'
 #  }
 #
 # === Authors

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,7 @@
 #
 class gradle::params {
   $version = $::gradle_version ? {
-    undef   => '1.6',
+    undef   => '1.8',
     default => $::gradle_version
   }
 


### PR DESCRIPTION
Gradle 1.8 was [released September 24, 2013](http://forums.gradle.org/gradle/topics/gradle_1_8_is_released). This bumps the default version to the latest gradle released version.
