### PR TITLE
Add root_dir to avoid endless unpacks

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,6 +89,7 @@ class gradle(
     checksum   => false,
     src_target => '/var/tmp',
     target     => '/opt',
+    root_dir   => "gradle-${version_real}",
     extension  => 'zip',
     timeout    => $timeout,
   }


### PR DESCRIPTION
Because the root_dir was not given, the $extract dir variable in the archive::extract class was set to '/opt/gradle-1.8-all.zip. This file never exists and thus the unpack happens every puppet run.
Setting the root_dir avoids this by specifying the top directory inside the archive.
